### PR TITLE
Update user group SLOs for five-tier quality support

### DIFF
--- a/config/user_groups/p10.yaml
+++ b/config/user_groups/p10.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.9
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.1
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p100.yaml
+++ b/config/user_groups/p100.yaml
@@ -3,8 +3,14 @@ groups:
   - name: premium
     weight: 1
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p20.yaml
+++ b/config/user_groups/p20.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.8
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.2
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p30.yaml
+++ b/config/user_groups/p30.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.7
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.3
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p40.yaml
+++ b/config/user_groups/p40.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.6
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.4
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p5.yaml
+++ b/config/user_groups/p5.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.95
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.05
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p50.yaml
+++ b/config/user_groups/p50.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.5
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.5
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p60.yaml
+++ b/config/user_groups/p60.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.4
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.6
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p70.yaml
+++ b/config/user_groups/p70.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.3
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.7
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p80.yaml
+++ b/config/user_groups/p80.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.2
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.8
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p90.yaml
+++ b/config/user_groups/p90.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.1
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.9
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p95.yaml
+++ b/config/user_groups/p95.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.05
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.95
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p96.yaml
+++ b/config/user_groups/p96.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.04
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.96
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p97.yaml
+++ b/config/user_groups/p97.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.03
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.97
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p98.yaml
+++ b/config/user_groups/p98.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.02
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.98
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1

--- a/config/user_groups/p99.yaml
+++ b/config/user_groups/p99.yaml
@@ -3,16 +3,28 @@ groups:
   - name: best-effort
     weight: 0.01
     slo_lower:
-      bad: 1
-      good: 0
+      tier_0: 1
+      tier_1: 0.75
+      tier_2: 0.5
+      tier_3: 0.25
+      tier_4: 0
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0.25
+      tier_2: 0.5
+      tier_3: 0.75
+      tier_4: 1
   - name: premium
     weight: 0.99
     slo_lower:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1
     slo_upper:
-      bad: 0
-      good: 1
+      tier_0: 0
+      tier_1: 0
+      tier_2: 0
+      tier_3: 0
+      tier_4: 1


### PR DESCRIPTION
## Summary
- replace binary good/bad SLO keys in percentile user group configs with tier_0 through tier_4 bounds
- align premium-only definitions so tier_4 represents the highest quality and tier_0 the lowest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9ed12ab88329991c4cd190a1d9e9